### PR TITLE
Update issue report form spreadsheet versioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yml
@@ -39,7 +39,7 @@ body:
       label: Version of spreadsheet
       description: Which spreadsheet version are you using?
       options:
-        - "v1.0"
+        - "v1.0.0"
         - Other / Not sure
     validations:
       required: true


### PR DESCRIPTION
This pull request makes a minor update to the issue template by clarifying the spreadsheet version option for users.

* Updated the spreadsheet version option from "v1.0" to "v1.0.0" in the `.github/ISSUE_TEMPLATE/issue-report.yml`